### PR TITLE
Refactor auth screens with shared components

### DIFF
--- a/ONJI/app/(auth)/BusinessDetailsScreen.tsx
+++ b/ONJI/app/(auth)/BusinessDetailsScreen.tsx
@@ -18,6 +18,7 @@ import * as Yup from "yup";
 import FormikTextInput from "../../components/auth/FormikTextInput";
 import RadioInput from "../../components/auth/RadioInput";
 import { router } from "expo-router";
+import AuthButton from "../../components/auth/AuthButton";
 
 const { height, width } = Dimensions.get("window");
 
@@ -201,21 +202,13 @@ export function BusinessDetailsScreen() {
                       )}
                     </View>
                     <View>
-                      <Pressable
-                        className="justify-center rounded-[12px] items-center h-[60] "
-                        disabled={!isValid}
-                        style={{
-                          backgroundColor: isValid ? "#4CAF50" : "#E0E0E0",
-                        }}
+                      <AuthButton
+                        title="Continue"
                         onPress={() => handleSubmit()}
-                      >
-                        <Text
-                          className="text-[20px]  font-primarysemibold"
-                          style={{ color: isValid ? "#F3FAF3" : "#AAB2B8" }}
-                        >
-                          Continue
-                        </Text>
-                      </Pressable>
+                        disabled={!isValid}
+                        containerStyle={{ height: 60, borderRadius: 12 }}
+                        textStyle={{ fontSize: 20 }}
+                      />
                     </View>
                   </View>
               )

--- a/ONJI/app/(auth)/login.tsx
+++ b/ONJI/app/(auth)/login.tsx
@@ -6,7 +6,6 @@ import {
   Text,
   View,
   TextInput,
-  TouchableOpacity,
   SafeAreaView,
   StatusBar,
   Image,
@@ -14,6 +13,7 @@ import {
   KeyboardAvoidingView,
 } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
+import AuthButton from '@/components/auth/AuthButton';
 import axiosInstance from '@/lib/api/axiosConfig';
 
 LogBox.ignoreLogs([
@@ -117,22 +117,13 @@ export default function CreateAccount() {
             )}
           </View>
 
-          <TouchableOpacity
-            style={[
-              styles.continueButton,
-              isButtonActive ? styles.continueButtonActive : styles.continueButtonDisabled
-            ]}
-            disabled={!isButtonActive || isLoading}
-            activeOpacity={0.8}
+          <AuthButton
+            title="Continue"
             onPress={handleContinue}
-          >
-            <Text style={[
-              styles.continueButtonText,
-              isButtonActive ? styles.continueButtonTextActive : styles.continueButtonTextDisabled
-            ]}>
-              {isLoading ? "Please wait..." : "Continue"}
-            </Text>
-          </TouchableOpacity>
+            loading={isLoading}
+            disabled={!isButtonActive}
+            containerStyle={styles.continueButton}
+          />
         </View>
       </KeyboardAvoidingView>
     </SafeAreaView>
@@ -237,20 +228,8 @@ const styles = StyleSheet.create({
     marginTop: 'auto',
     marginBottom: 40,
   },
-  continueButtonActive: {
-    backgroundColor: '#4CAF50',
-  },
-  continueButtonDisabled: {
-    backgroundColor: '#E0E0E0',
-  },
   continueButtonText: {
     fontSize: 16,
     fontWeight: '600',
-  },
-  continueButtonTextActive: {
-    color: '#FFFFFF',
-  },
-  continueButtonTextDisabled: {
-    color: '#9E9E9E',
   },
 });

--- a/ONJI/app/(auth)/otpverify.tsx
+++ b/ONJI/app/(auth)/otpverify.tsx
@@ -4,7 +4,6 @@ import {
   Alert,
   Dimensions,
   Image,
-  Keyboard,
   StatusBar,
   StyleSheet,
   TextInput,
@@ -13,6 +12,8 @@ import {
 } from 'react-native';
 import { useLocalSearchParams, router } from 'expo-router';
 import axiosInstance from '@/lib/api/axiosConfig';
+import AuthButton from '@/components/auth/AuthButton';
+import OTPInput from '@/components/auth/OTPInput';
 
 const { width, height } = Dimensions.get('window');
 
@@ -43,27 +44,6 @@ export default function OTPVerification() {
     }
   }, [showSuccessMessage]);
 
-  const handleOtpChange = (value: string, index: number) => {
-    if (value.length > 1) return;
-    const newOtp = [...otp];
-    newOtp[index] = value;
-    setOtp(newOtp);
-    if (isError) {
-      setIsError(false);
-      setErrorMessage('');
-    }
-    if (value && index < 5) {
-      inputRefs.current[index + 1]?.focus();
-    } else if (value && index === 5) {
-      Keyboard.dismiss();
-    }
-  };
-
-  const handleKeyPress = (key: string, index: number) => {
-    if (key === 'Backspace' && !otp[index] && index > 0) {
-      inputRefs.current[index - 1]?.focus();
-    }
-  };
 
   const isOtpComplete = otp.every(digit => digit !== '');
 
@@ -140,28 +120,13 @@ export default function OTPVerification() {
         <ThemedText style={styles.title}>
           Enter the 6 digit code sent via SMS to{'\n'}{phoneNumber}
         </ThemedText>
-        <View style={styles.otpContainer}>
-          {otp.map((digit, index) => (
-            <TextInput
-              key={index}
-              ref={(ref) => {
-                if (ref) inputRefs.current[index] = ref;
-              }}
-              style={[
-                styles.otpInput,
-                isError && styles.otpInputError,
-                digit && styles.otpInputFilled
-              ]}
-              value={digit}
-              onChangeText={(value) => handleOtpChange(value, index)}
-              onKeyPress={({ nativeEvent }) => handleKeyPress(nativeEvent.key, index)}
-              keyboardType="numeric"
-              maxLength={1}
-              selectTextOnFocus
-              textAlign="center"
-            />
-          ))}
-        </View>
+        <OTPInput
+          value={otp}
+          onChange={setOtp}
+          inputRefs={inputRefs}
+          containerStyle={styles.otpContainer}
+          isError={isError}
+        />
 
         {isError && (
           <ThemedText style={styles.errorText}>{errorMessage}</ThemedText>
@@ -184,21 +149,14 @@ export default function OTPVerification() {
             <ThemedText style={styles.changeNumberText}>Change mobile number</ThemedText>
           </TouchableOpacity>
         </View>
-        <TouchableOpacity
-          style={[
-            styles.continueButton,
-            (!isOtpComplete || isVerifying) && styles.continueButtonDisabled
-          ]}
+        <AuthButton
+          title="Continue"
           onPress={handleContinue}
-          disabled={!isOtpComplete || isVerifying}
-        >
-          <ThemedText style={[
-            styles.continueText,
-            (!isOtpComplete || isVerifying) && styles.continueTextDisabled
-          ]}>
-            {isVerifying ? 'Verifying...' : 'Continue'}
-          </ThemedText>
-        </TouchableOpacity>
+          loading={isVerifying}
+          disabled={!isOtpComplete}
+          containerStyle={styles.continueButton}
+          textStyle={styles.continueText}
+        />
       </View>
     </View>
   );
@@ -332,17 +290,11 @@ const styles = StyleSheet.create({
     marginTop: 'auto',
     marginBottom: 34,
   },
-  continueButtonDisabled: {
-    backgroundColor: '#E0E0E0',
-  },
   continueText: {
     color: '#fff',
     fontSize: 16,
     fontWeight: '600',
     letterSpacing: 0.5,
     textAlign: 'center',
-  },
-  continueTextDisabled: {
-    color: '#999',
   },
 });

--- a/ONJI/components/auth/AuthButton.tsx
+++ b/ONJI/components/auth/AuthButton.tsx
@@ -1,4 +1,74 @@
-// Authentication button component placeholder
-export function AuthButton() {
-  return null;
+import React from 'react';
+import {
+  TouchableOpacity,
+  Text,
+  StyleSheet,
+  ViewStyle,
+  TextStyle,
+} from 'react-native';
+
+interface AuthButtonProps {
+  title: string;
+  onPress: () => void;
+  disabled?: boolean;
+  loading?: boolean;
+  containerStyle?: ViewStyle;
+  textStyle?: TextStyle;
 }
+
+export default function AuthButton({
+  title,
+  onPress,
+  disabled = false,
+  loading = false,
+  containerStyle,
+  textStyle,
+}: AuthButtonProps) {
+  return (
+    <TouchableOpacity
+      activeOpacity={0.8}
+      style={[
+        styles.button,
+        disabled ? styles.buttonDisabled : styles.buttonEnabled,
+        containerStyle,
+      ]}
+      onPress={onPress}
+      disabled={disabled || loading}
+    >
+      <Text
+        style={[
+          styles.text,
+          disabled ? styles.textDisabled : styles.textEnabled,
+          textStyle,
+        ]}
+      >
+        {loading ? 'Please wait...' : title}
+      </Text>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    height: 56,
+    borderRadius: 12,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  buttonEnabled: {
+    backgroundColor: '#4CAF50',
+  },
+  buttonDisabled: {
+    backgroundColor: '#E0E0E0',
+  },
+  text: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  textEnabled: {
+    color: '#FFFFFF',
+  },
+  textDisabled: {
+    color: '#9E9E9E',
+  },
+});

--- a/ONJI/components/auth/OTPInput.tsx
+++ b/ONJI/components/auth/OTPInput.tsx
@@ -1,4 +1,88 @@
-// OTPInput component placeholder
-export function OTPInput() {
-  return null;
+import React, { useRef } from 'react';
+import { View, TextInput, StyleSheet, ViewStyle } from 'react-native';
+
+interface OTPInputProps {
+  length?: number;
+  value: string[];
+  onChange: (value: string[]) => void;
+  containerStyle?: ViewStyle;
+  inputRefs?: React.MutableRefObject<TextInput[]>;
+  isError?: boolean;
 }
+
+export default function OTPInput({
+  length = 6,
+  value,
+  onChange,
+  containerStyle,
+  inputRefs,
+  isError = false,
+}: OTPInputProps) {
+  const refs = inputRefs || useRef<TextInput[]>([]);
+
+  const handleChange = (val: string, index: number) => {
+    if (val.length > 1) return;
+    const newVal = [...value];
+    newVal[index] = val;
+    onChange(newVal);
+    if (val && index < length - 1) {
+      refs.current[index + 1]?.focus();
+    }
+  };
+
+  const handleKeyPress = (key: string, index: number) => {
+    if (key === 'Backspace' && !value[index] && index > 0) {
+      refs.current[index - 1]?.focus();
+    }
+  };
+
+  return (
+    <View style={[styles.container, containerStyle]}>
+      {Array.from({ length }).map((_, idx) => (
+        <TextInput
+          key={idx}
+          ref={(ref) => {
+            if (ref) refs.current[idx] = ref;
+          }}
+          style={[
+            styles.input,
+            isError && styles.inputError,
+            value[idx] && styles.inputFilled,
+          ]}
+          value={value[idx]}
+          onChangeText={(v) => handleChange(v, idx)}
+          onKeyPress={({ nativeEvent }) => handleKeyPress(nativeEvent.key, idx)}
+          keyboardType="numeric"
+          maxLength={1}
+          selectTextOnFocus
+          textAlign="center"
+        />
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  input: {
+    width: 48,
+    height: 56,
+    borderWidth: 2,
+    borderColor: '#E8E8E8',
+    borderRadius: 12,
+    fontSize: 20,
+    fontWeight: '600',
+    backgroundColor: '#fff',
+    color: '#333',
+  },
+  inputFilled: {
+    borderColor: '#4CAF50',
+  },
+  inputError: {
+    borderColor: '#FF5252',
+  },
+});
+


### PR DESCRIPTION
## Summary
- implement reusable `AuthButton` component for consistent styling
- add flexible `OTPInput` component to render OTP digit inputs
- refactor login, OTP verification and business details screens to use new components

## Testing
- `npm test` *(fails: Missing script)*
- `./mvnw -q test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68867c877844832da9f74d8e26ff1615