### PR TITLE
Implement secure token storage

### DIFF
--- a/ONJI/app/(auth)/otpverify.tsx
+++ b/ONJI/app/(auth)/otpverify.tsx
@@ -13,6 +13,7 @@ import {
 } from 'react-native';
 import { useLocalSearchParams, router } from 'expo-router';
 import axiosInstance from '@/lib/api/axiosConfig';
+import { saveTokens } from '@/lib/secureToken';
 
 const { width, height } = Dimensions.get('window');
 
@@ -78,11 +79,13 @@ export default function OTPVerification() {
     setIsVerifying(true);
     const enteredOtp = otp.join('');
     try {
-      
-      await axiosInstance.post('/api/auth/login', {
+      const response = await axiosInstance.post('/api/auth/login', {
         phoneNumber: phoneNumber,
         otpNumber: enteredOtp,
       });
+
+      // Store received tokens securely
+      await saveTokens(response.data.jwtToken, response.data.refreshToken);
 
       setIsError(false);
       setErrorMessage('');

--- a/ONJI/lib/api/axiosConfig.ts
+++ b/ONJI/lib/api/axiosConfig.ts
@@ -1,28 +1,27 @@
 import axios from 'axios';
-
+import { getAccessToken } from '@/lib/secureToken';
 
 const axiosInstance = axios.create({
-  baseURL: 'https://216173960ae7.ngrok-free.app', 
-  headers: {
-    'Content-Type': 'application/json',
-    'ngrok-skip-browser-warning': 'true',
-  },
+  baseURL: 'https://216173960ae7.ngrok-free.app',
+  headers: {
+    'Content-Type': 'application/json',
+    'ngrok-skip-browser-warning': 'true',
+  },
 });
 
-// Optional: Add interceptors (e.g., auth tokens)
+// Attach the stored access token to each request if available
 axiosInstance.interceptors.request.use(
-  async (config) => {
-    // You can inject tokens here if needed (e.g. using AsyncStorage or SecureStore)
-    // const token = await AsyncStorage.getItem('token');
-    // if (token) {
-    //   config.headers.Authorization = `Bearer ${token}`;
-    // }
+  async (config) => {
+    const token = await getAccessToken();
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
 
-    return config;
-  },
-  (error) => {
-    return Promise.reject(error);
-  }
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
 );
 
 export default axiosInstance;

--- a/ONJI/lib/secureToken.ts
+++ b/ONJI/lib/secureToken.ts
@@ -1,0 +1,26 @@
+import * as SecureStore from 'expo-secure-store';
+
+const ACCESS_TOKEN_KEY = 'accessToken';
+const REFRESH_TOKEN_KEY = 'refreshToken';
+
+export async function saveTokens(accessToken: string, refreshToken: string): Promise<void> {
+  await SecureStore.setItemAsync(ACCESS_TOKEN_KEY, accessToken, {
+    keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK,
+  });
+  await SecureStore.setItemAsync(REFRESH_TOKEN_KEY, refreshToken, {
+    keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK,
+  });
+}
+
+export async function getAccessToken(): Promise<string | null> {
+  return SecureStore.getItemAsync(ACCESS_TOKEN_KEY);
+}
+
+export async function getRefreshToken(): Promise<string | null> {
+  return SecureStore.getItemAsync(REFRESH_TOKEN_KEY);
+}
+
+export async function clearTokens(): Promise<void> {
+  await SecureStore.deleteItemAsync(ACCESS_TOKEN_KEY);
+  await SecureStore.deleteItemAsync(REFRESH_TOKEN_KEY);
+}

--- a/ONJI/package-lock.json
+++ b/ONJI/package-lock.json
@@ -26,6 +26,7 @@
         "expo-linear-gradient": "~14.1.5",
         "expo-linking": "7.1.7",
         "expo-router": "5.1.3",
+        "expo-secure-store": "^14.2.3",
         "expo-splash-screen": "0.30.10",
         "expo-status-bar": "~2.2.3",
         "expo-symbols": "~0.4.5",
@@ -6628,6 +6629,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/expo-secure-store": {
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-14.2.3.tgz",
+      "integrity": "sha512-hYBbaAD70asKTFd/eZBKVu+9RTo9OSTMMLqXtzDF8ndUGjpc6tmRCoZtrMHlUo7qLtwL5jm+vpYVBWI8hxh/1Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-splash-screen": {

--- a/ONJI/package.json
+++ b/ONJI/package.json
@@ -29,6 +29,7 @@
     "expo-linear-gradient": "~14.1.5",
     "expo-linking": "7.1.7",
     "expo-router": "5.1.3",
+    "expo-secure-store": "^14.2.3",
     "expo-splash-screen": "0.30.10",
     "expo-status-bar": "~2.2.3",
     "expo-symbols": "~0.4.5",


### PR DESCRIPTION
## Summary
- add `expo-secure-store` and create secure token helpers
- attach access token in axios requests
- save JWT and refresh tokens after OTP verification

## Testing
- `npm run lint`
- `mvn -q test` *(fails: Network is unreachable)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68868186e7a4832d86f6516f2b50a43a