### PR TITLE
Add dynamic import example for screens

### DIFF
--- a/ONJI/README.md
+++ b/ONJI/README.md
@@ -42,6 +42,20 @@ To learn more about developing your project with Expo, look at the following res
 - [Expo documentation](https://docs.expo.dev/): Learn fundamentals, or go into advanced topics with our [guides](https://docs.expo.dev/guides).
 - [Learn Expo tutorial](https://docs.expo.dev/tutorial/introduction/): Follow a step-by-step tutorial where you'll create a project that runs on Android, iOS, and the web.
 
+## Lazy loading screens
+
+React Navigation supports dynamic `import()` for screens. You can use the `getComponent` prop on a screen to load it only when it's first needed:
+
+```tsx
+// Example: app/(auth)/_layout.tsx
+<Stack.Screen
+  name="login"
+  getComponent={() => import('./login').then((m) => m.default)}
+/>
+```
+
+This reduces the initial bundle size because the `login` screen's code is downloaded on demand when a user navigates to it.
+
 ## Join the community
 
 Join our community of developers creating universal apps.

--- a/ONJI/app/(auth)/_layout.tsx
+++ b/ONJI/app/(auth)/_layout.tsx
@@ -5,7 +5,10 @@ export default function AuthLayout() {
     <Stack screenOptions={{ headerShown: false }}>
       <Stack.Screen name="SplashScreen" />
       <Stack.Screen name="index" />
-      <Stack.Screen name="login" />
+      <Stack.Screen
+        name="login"
+        getComponent={() => import('./login').then((m) => m.default)}
+      />
       <Stack.Screen name="otpverify" />
       <Stack.Screen name="BusinessDetailsScreen"/>
     </Stack>


### PR DESCRIPTION
## Summary
- demonstrate dynamic import of the login screen
- document how to lazy load screens with `getComponent`

## Testing
- `npx expo --version`
- `npm install --no-progress`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68868199d3c8832d94163e8a5102e042