### PR TITLE
Reduce payload size in DTO responses

### DIFF
--- a/src/main/java/com/sattva/dto/CategoryDTO.java
+++ b/src/main/java/com/sattva/dto/CategoryDTO.java
@@ -1,6 +1,6 @@
 package com.sattva.dto;
 
-import java.util.List;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -13,11 +13,9 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class CategoryDTO {
-	 private String id;
-	    
-	    private String name; 
-	    
-	    private String description;
-	    private List<SubCategoryDTO> subCategories;
+    private String id;
+    private String name;
+    private String description;
 }

--- a/src/main/java/com/sattva/dto/ProductDTO.java
+++ b/src/main/java/com/sattva/dto/ProductDTO.java
@@ -1,5 +1,6 @@
 package com.sattva.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sattva.enums.QuantityType;
 
 import lombok.AllArgsConstructor;
@@ -11,6 +12,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ProductDTO {
     private String productId;
     private String name;

--- a/src/main/java/com/sattva/dto/SubCategoryDTO.java
+++ b/src/main/java/com/sattva/dto/SubCategoryDTO.java
@@ -1,6 +1,6 @@
 package com.sattva.dto;
 
-import java.util.List;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -11,10 +11,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SubCategoryDTO {
     private String id;
     private String name;
     private String description;
-    private String categoryId; 
-    private List<ProductDTO> products;
+    private String categoryId;
 }

--- a/src/main/java/com/sattva/dto/UserDTO.java
+++ b/src/main/java/com/sattva/dto/UserDTO.java
@@ -6,6 +6,8 @@ import java.util.Set;
 import com.sattva.enums.UserStatus;
 import com.sattva.enums.UserType;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -13,6 +15,7 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class UserDTO {
 
     private String id;                   


### PR DESCRIPTION
## Summary
- trim nested lists from `CategoryDTO` and `SubCategoryDTO`
- avoid null output in several DTOs with `@JsonInclude`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688681a3ca00832d90d048b556a364f3