### PR TITLE
feat: add category-based supplier mapping for products

### DIFF
--- a/src/main/java/com/sattva/controller/ProductController.java
+++ b/src/main/java/com/sattva/controller/ProductController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.sattva.dto.ProductDTO;
@@ -60,4 +61,16 @@ public class ProductController {
         List<ProductDTO> products = productService.getProductsBySubcategoryId(subCategoryId);
         return ResponseEntity.ok(products);
     }
+    //
+    @PostMapping("/map-by-category")
+    public ResponseEntity<?> mapByCategory(
+            @RequestParam String categoryId,
+            @RequestParam String supplierId) {
+
+        productService.mapProductsByCategory(categoryId, supplierId);
+
+        return ResponseEntity.ok("Products mapped successfully");
+    }
+
+
 }

--- a/src/main/java/com/sattva/dto/ProductSupplierMapRequest.java
+++ b/src/main/java/com/sattva/dto/ProductSupplierMapRequest.java
@@ -1,0 +1,10 @@
+package com.sattva.dto;
+
+import lombok.Data;
+
+@Data
+public class ProductSupplierMapRequest {
+
+    private String productId;
+    private String supplierId;
+}

--- a/src/main/java/com/sattva/model/Product.java
+++ b/src/main/java/com/sattva/model/Product.java
@@ -51,4 +51,8 @@ public class Product {
     @ManyToOne
     @JoinColumn(name = "subcategory_id", nullable = true)
     private SubCategory subCategory;
+
+    @ManyToOne
+    @JoinColumn(name = "supplier_id")
+    private Supplier supplier;
 }

--- a/src/main/java/com/sattva/repository/ProductRepository.java
+++ b/src/main/java/com/sattva/repository/ProductRepository.java
@@ -15,4 +15,7 @@ public interface ProductRepository extends JpaRepository<Product, String> {
     boolean existsByImageUrl(String imageUrl);
 
     Optional<Product> findByImageUrl(String imageUrl);
+
+    //Finding all the product based on category
+    List<Product> findByCategory_Id(String categoryId);
 }

--- a/src/main/java/com/sattva/service/ProductService.java
+++ b/src/main/java/com/sattva/service/ProductService.java
@@ -11,4 +11,7 @@ public interface ProductService {
     ProductDTO updateProduct(String productId, ProductDTO productDTO);
     void deleteProduct(String productId);
     List<ProductDTO> getProductsBySubcategoryId(String subCategoryId);
+
+    //Map all products of a category to a supplier
+    void mapProductsByCategory(String categoryId, String supplierId);
 }

--- a/src/main/java/com/sattva/service/impl/ProductServiceImpl.java
+++ b/src/main/java/com/sattva/service/impl/ProductServiceImpl.java
@@ -16,7 +16,9 @@ import com.sattva.model.SubCategory;
 import com.sattva.repository.CategoryRepository;
 import com.sattva.repository.ProductRepository;
 import com.sattva.repository.SubCategoryRepository;
+import com.sattva.repository.SupplierRepository;
 import com.sattva.service.ProductService;
+import com.sattva.model.Supplier;
 
 @Service
 public class ProductServiceImpl implements ProductService {
@@ -32,6 +34,9 @@ public class ProductServiceImpl implements ProductService {
 
     @Autowired
     private ModelMapper modelMapper;
+
+    @Autowired
+    private SupplierRepository supplierRepository; 
 
     @Override
     public List<ProductDTO> getAllProducts() {
@@ -127,5 +132,32 @@ public class ProductServiceImpl implements ProductService {
         return products.stream()
                 .map(product -> modelMapper.map(product, ProductDTO.class))
                 .collect(Collectors.toList());
+    }
+
+    //MAP PRODUCTS BY CATEGORY
+    @Override
+    public void mapProductsByCategory(String categoryId, String supplierId) {
+
+        // Fetch supplier
+        Supplier supplier = supplierRepository.findById(supplierId)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Supplier not found with id: " + supplierId));
+
+        //Fetch all products of given category
+        List<Product> products = productRepository.findByCategory_Id(categoryId);
+
+        //If no products found → error
+        if (products.isEmpty()) {
+            throw new ResourceNotFoundException(
+                    "No products found for category id: " + categoryId);
+        }
+
+        //Assign supplier to each product
+        products.forEach(product -> product.setSupplier(supplier));
+
+        //Save all updated products
+        productRepository.saveAll(products);
+
+        System.out.println("All products mapped to supplier successfully");
     }
 }


### PR DESCRIPTION
Introduced a new API to map all products under a given category to a supplier in a single call. Implemented service logic to fetch products by category, assign the supplier, and save updates in bulk.
Tested using Postman and verified changes in the database.
