### PR TITLE
Hide accepted suppliers from find new suppliers list

### DIFF
--- a/src/main/java/com/sattva/service/impl/RetailerServiceImpl.java
+++ b/src/main/java/com/sattva/service/impl/RetailerServiceImpl.java
@@ -153,6 +153,23 @@ public class RetailerServiceImpl implements RetailerService {
                 })
                 .collect(Collectors.toList());
 
+                // Fetch accepted connections for this retailer
+                List<Connection> acceptedConnections =
+                        connectionRepository.findByRetailerIdAndStatus(
+                                retailerId,
+                                ConnectionStatus.ACCEPTED
+                        );
+
+                // Extract connected supplier IDs
+                List<String> connectedSupplierIds = acceptedConnections.stream()
+                        .map(Connection::getSupplierId)
+                        .collect(Collectors.toList());
+
+                // Remove already connected suppliers
+                suppliers = suppliers.stream()
+                        .filter(supplier -> !connectedSupplierIds.contains(supplier.getId()))
+                        .collect(Collectors.toList());
+
         return suppliers.stream()
                 .map(this::convertToDTO)
                 .collect(Collectors.toList());


### PR DESCRIPTION
Implemented filtering logic in the “Find New Suppliers” API to exclude suppliers whose connection status is ACCEPTED for a retailer. This ensures connected suppliers appear only in the “My Suppliers” list. Changes were tested successfully using Postman.
