### PR TITLE
Implement supplier edit order API

### DIFF
--- a/src/main/java/com/sattva/controller/OrderController.java
+++ b/src/main/java/com/sattva/controller/OrderController.java
@@ -3,6 +3,7 @@ package com.sattva.controller;
 import com.sattva.dto.OrderDTO;
 import com.sattva.dto.OrderItemDTO;
 import com.sattva.dto.CreateOrderRequestDTO;
+import com.sattva.dto.EditOrderRequestDTO;
 import com.sattva.enums.OrderItemStatus;
 import com.sattva.enums.OrderStatus;
 import com.sattva.service.OrderService;
@@ -180,6 +181,18 @@ public class OrderController {
         OrderDTO order = orderService.getOrderById(orderId);
 
         return ResponseEntity.ok(order);
+    }
+
+    // Edit all order items before supplier confirms the order.
+    // This API only saves the edited values.
+    @PutMapping("/{orderId}/edit")
+    public ResponseEntity<OrderDTO> editOrder(
+            @PathVariable String orderId,
+            @RequestBody EditOrderRequestDTO request) {
+
+        return ResponseEntity.ok(
+                orderService.editOrder(orderId, request)
+        );
     }
 
 }

--- a/src/main/java/com/sattva/dto/EditOrderItemRequestDTO.java
+++ b/src/main/java/com/sattva/dto/EditOrderItemRequestDTO.java
@@ -1,0 +1,11 @@
+package com.sattva.dto;
+
+import lombok.Data;
+
+@Data
+public class EditOrderItemRequestDTO {
+
+    private String itemId;
+    private Integer fulfilledQuantity;
+    private Double unitPrice;
+}

--- a/src/main/java/com/sattva/dto/EditOrderRequestDTO.java
+++ b/src/main/java/com/sattva/dto/EditOrderRequestDTO.java
@@ -1,0 +1,11 @@
+package com.sattva.dto;
+
+import java.util.List;
+
+import lombok.Data;
+
+@Data
+public class EditOrderRequestDTO {
+
+    private List<EditOrderItemRequestDTO> items;
+}

--- a/src/main/java/com/sattva/service/OrderService.java
+++ b/src/main/java/com/sattva/service/OrderService.java
@@ -3,6 +3,7 @@ package com.sattva.service;
 import java.util.List;
 
 import com.sattva.dto.CreateOrderRequestDTO;
+import com.sattva.dto.EditOrderRequestDTO;
 import com.sattva.dto.OrderDTO;
 import com.sattva.dto.OrderItemDTO;
 import com.sattva.enums.OrderItemStatus;
@@ -31,4 +32,7 @@ public interface OrderService {
 
     // Get retailer order details by order ID
     OrderDTO getOrderById(String orderId);
+
+    // Edit all order items before supplier confirms the order.
+    OrderDTO editOrder(String orderId,EditOrderRequestDTO request);
 }

--- a/src/main/java/com/sattva/service/impl/OrderServiceImpl.java
+++ b/src/main/java/com/sattva/service/impl/OrderServiceImpl.java
@@ -11,6 +11,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.sattva.dto.CreateOrderRequestDTO;
+import com.sattva.dto.EditOrderItemRequestDTO;
+import com.sattva.dto.EditOrderRequestDTO;
 import com.sattva.dto.OrderDTO;
 import com.sattva.dto.OrderItemDTO;
 import com.sattva.enums.OrderItemStatus;
@@ -389,5 +391,70 @@ public class OrderServiceImpl implements OrderService {
         // Convert entity to DTO
         return convertToDTO(order);
     }
+
+        // Saves edited quantities and prices for all order items
+        // before the supplier confirms the order.
+        @Override
+        @Transactional
+        public OrderDTO editOrder(String orderId,
+                                EditOrderRequestDTO request) {
+
+        // Fetch the order
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() ->
+                        new ResourceNotFoundException(
+                                "Order not found with ID: " + orderId
+                        ));
+
+        // Update each edited order item
+        for (EditOrderItemRequestDTO editedItem : request.getItems()) {
+
+                // Fetch the order item
+                OrderItem orderItem = orderItemRepository.findById(editedItem.getItemId())
+                        .orElseThrow(() ->
+                                new ResourceNotFoundException(
+                                        "Order item not found with ID: " + editedItem.getItemId()
+                                ));
+                                
+                // Validate that the order item belongs to the given order
+                if (!orderItem.getOrder().getId().equals(orderId)) {
+                        throw new InvalidInputException(
+                                "Order item does not belong to the given order."
+                        );
+                }
+
+                // Check if the order item is still editable
+                if (!orderItem.isEditable()) {
+                        throw new InvalidInputException(
+                                "This order item can no longer be edited."
+                        );
+                }
+
+
+                // Update fulfilled quantity
+                if (editedItem.getFulfilledQuantity() != null) {
+                orderItem.setFulfilledQuantity(editedItem.getFulfilledQuantity());
+                }
+
+                // Update unit price
+                if (editedItem.getUnitPrice() != null) {
+                orderItem.setUnitPrice(editedItem.getUnitPrice());
+                }
+
+                // Recalculate total price
+                orderItem.setTotalPrice(
+                        orderItem.getUnitPrice() * orderItem.getFulfilledQuantity()
+                );
+
+                // Save updated order item
+                orderItemRepository.save(orderItem);
+        }
+
+        // Save updated order
+        // orderRepository.save(order);
+
+        // Return updated order
+        return convertToDTO(order);
+        }
 
 }


### PR DESCRIPTION
Added a new endpoint:

PUT /api/orders/{orderId}/edit

This API allows the supplier to edit all order items in a single request before confirming the order. It updates the fulfilled quantity and unit price for each editable order item, recalculates the total price, validates that the item belongs to the given order and is still editable, and returns the updated order details.