### PR TITLE
Implement order-level fulfillment flow

### DIFF
--- a/src/main/java/com/sattva/controller/OrderController.java
+++ b/src/main/java/com/sattva/controller/OrderController.java
@@ -195,4 +195,14 @@ public class OrderController {
         );
     }
 
+    // Fulfill the complete order after supplier confirmation.
+    @PutMapping("/{orderId}/fulfill")
+    public ResponseEntity<OrderDTO> fulfillOrder(
+            @PathVariable String orderId) {
+
+        return ResponseEntity.ok(
+                orderService.fulfillOrder(orderId)
+        );
+    }
+
 }

--- a/src/main/java/com/sattva/dto/OrderItemDTO.java
+++ b/src/main/java/com/sattva/dto/OrderItemDTO.java
@@ -34,4 +34,6 @@ public class OrderItemDTO {
     private boolean editable; // Indicates whether the item can still be edited by the supplier
 
     private Integer availableQuantity; // Quantity currently available in stock
+
+    private boolean edited; // Indicates whether the supplier has edited this order item.
 }

--- a/src/main/java/com/sattva/model/OrderItem.java
+++ b/src/main/java/com/sattva/model/OrderItem.java
@@ -54,4 +54,5 @@ public class OrderItem {
     private boolean isEditable = true; // Indicates whether this item can be edited
     private boolean isFulfilled = false; // Indicates whether this item has been fulfilled
     private boolean isBackordered = false; // Indicates whether the item is backordered
+    private boolean isEdited = false; // Indicates whether the supplier has edited this order item
 }

--- a/src/main/java/com/sattva/service/OrderService.java
+++ b/src/main/java/com/sattva/service/OrderService.java
@@ -35,4 +35,8 @@ public interface OrderService {
 
     // Edit all order items before supplier confirms the order.
     OrderDTO editOrder(String orderId,EditOrderRequestDTO request);
+
+    //Fullfill the complete order after supplier confirmation.
+    OrderDTO fulfillOrder(String orderId);
+
 }

--- a/src/main/java/com/sattva/service/impl/OrderServiceImpl.java
+++ b/src/main/java/com/sattva/service/impl/OrderServiceImpl.java
@@ -472,4 +472,78 @@ public class OrderServiceImpl implements OrderService {
         return convertToDTO(order);
         }
 
+        @Override
+        @Transactional
+        public OrderDTO fulfillOrder(String orderId) {
+
+        // Fetch the order
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() ->
+                        new ResourceNotFoundException(
+                                "Order not found with ID: " + orderId
+                        ));
+
+        // Track whether at least one item was fulfilled
+        boolean hasFulfilledItems = false;
+
+        // Fulfill each order item
+        for (OrderItem orderItem : order.getItems()) {
+
+                // Check if the order item is still editable
+                if (!orderItem.isEditable()) {
+                throw new InvalidInputException(
+                        "This order item is no longer editable."
+                );
+                }
+
+                // Check whether the product is out of stock
+                if (orderItem.getProduct().getStockQuantity() <= 0) {
+
+                orderItem.setStatus(OrderItemStatus.OUT_OF_STOCK);
+                orderItem.setFulfilled(false);
+                orderItem.setBackordered(false);
+                orderItem.setFulfilledQuantity(0);
+                orderItem.setEditable(true);
+
+                orderItemRepository.save(orderItem);
+
+                // Continue with the remaining order items
+                continue;
+                }
+
+                // If supplier didn't edit the quantity,
+                // fulfill the originally requested quantity.
+                if (orderItem.getFulfilledQuantity() == 0) {
+                orderItem.setFulfilledQuantity(
+                        orderItem.getRequestedQuantity()
+                );
+                }
+
+                // Recalculate total price
+                orderItem.setTotalPrice(
+                        orderItem.getUnitPrice() * orderItem.getFulfilledQuantity()
+                );
+
+                // Mark the item as fulfilled
+                orderItem.setStatus(OrderItemStatus.FULFILLED);
+                orderItem.setFulfilled(true);
+                orderItem.setBackordered(false);
+                orderItem.setEditable(false);
+
+                orderItemRepository.save(orderItem);
+
+                hasFulfilledItems = true;
+        }
+
+        // Update the order status only if at least one item was fulfilled
+        if (hasFulfilledItems) {
+                order.setStatus(OrderStatus.PROCESSING);
+        }
+
+        // Save the updated order
+        orderRepository.save(order);
+
+        // Return updated order details
+        return convertToDTO(order);
+        }
 }

--- a/src/main/java/com/sattva/service/impl/OrderServiceImpl.java
+++ b/src/main/java/com/sattva/service/impl/OrderServiceImpl.java
@@ -168,6 +168,9 @@ public class OrderServiceImpl implements OrderService {
                 orderItem.getProduct().getStockQuantity()
         );
 
+        // Indicates whether this order item has been edited.
+       dto.setEdited(orderItem.isEdited());
+
         return dto;
         }
    private OrderDTO convertToDTO(Order order) {
@@ -460,6 +463,9 @@ public class OrderServiceImpl implements OrderService {
                 orderItem.setTotalPrice(
                         orderItem.getUnitPrice() * orderItem.getFulfilledQuantity()
                 );
+
+                // Mark item as edited
+                orderItem.setEdited(true);
 
                 // Save updated order item
                 orderItemRepository.save(orderItem);


### PR DESCRIPTION
- Added a new order-level Fulfill API.
- Integrated fulfillment with the Edit API to use edited quantity and price.
- Added fallback to requested quantity when no edits are made.
- Implemented out-of-stock handling without rejecting the entire order.
- Locked fulfilled items from further editing.
- Updated order status to PROCESSING after successful fulfillment.
- Tested edit, direct fulfill, and out-of-stock scenarios using Postman