### PR TITLE
Restrict users to a single user type per phone number

### DIFF
--- a/src/main/java/com/sattva/controller/AuthController.java
+++ b/src/main/java/com/sattva/controller/AuthController.java
@@ -7,6 +7,7 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.gson.GsonFactory;
 import com.sattva.enums.UserType;
+import com.sattva.exception.ConflictException;
 import com.sattva.repository.RefreshTokenRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -29,7 +30,6 @@ import com.sattva.security.JwtHelper;
 import com.sattva.service.RefreshTokenService;
 import com.sattva.service.SmsService;
 import com.sattva.service.UserService;
-
 import javax.imageio.spi.IIORegistry;
 import javax.management.Query;
 
@@ -74,6 +74,15 @@ public class AuthController {
 
         if (existUser) {
             User existingUser = existing.get();
+
+            if (userDto.getUserType() != null &&
+                existingUser.getUserType() != null &&
+                UserType.valueOf(userDto.getUserType().toUpperCase()) != existingUser.getUserType()) {
+
+                throw new ConflictException(
+                    "An account already exists with this phone number."
+                );
+            }
             userId = existingUser.getId();
             fullName = existingUser.getFullName();
             userOnboardingStatus = existingUser.isUserOnboardingStatus();

--- a/src/main/java/com/sattva/service/impl/RetailerServiceImpl.java
+++ b/src/main/java/com/sattva/service/impl/RetailerServiceImpl.java
@@ -15,6 +15,7 @@ import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import com.sattva.exception.ConflictException;
 import com.sattva.exception.ResourceNotFoundException;
 import com.sattva.service.RetailerService;
 import com.sattva.service.UserService;
@@ -203,6 +204,12 @@ public class RetailerServiceImpl implements RetailerService {
 
         User user = userRepository.findById(dto.getRetailerId())
                 .orElseThrow(() -> new ResourceNotFoundException("User not found"));
+        
+        if (supplierRepository.existsById(user.getId())) {
+                throw new ConflictException(
+                        "User is already registered as a supplier and cannot become a retailer."
+                );
+        }
 
         Retailer retailer = retailerRepository.findById(dto.getRetailerId())
                 .orElseGet(() -> retailerRepository.save(
@@ -210,6 +217,12 @@ public class RetailerServiceImpl implements RetailerService {
                                 .user(user)
                                 .build()
                 ));
+
+        if (user.getUserType() != null && user.getUserType() != UserType.RETAILER) {
+        throw new ConflictException("User type cannot be changed.");
+        }
+
+        user.setUserType(UserType.RETAILER);
 
         user.setUserType(UserType.valueOf(dto.getUserType().toUpperCase()));
         user.setUserOnboardingStatus(true);

--- a/src/main/java/com/sattva/service/impl/SupplierServiceImpl.java
+++ b/src/main/java/com/sattva/service/impl/SupplierServiceImpl.java
@@ -6,6 +6,7 @@ import com.sattva.model.*;
 import com.sattva.repository.*;
 import org.springframework.stereotype.Service;
 
+import com.sattva.exception.ConflictException;
 import com.sattva.exception.ResourceNotFoundException;
 import com.sattva.service.SupplierService;
 
@@ -57,6 +58,12 @@ public class SupplierServiceImpl implements SupplierService {
         User user = userRepository.findById(dto.getSupplierId())
                 .orElseThrow(() -> new ResourceNotFoundException("User not found"));
 
+        if (retailerRepository.existsById(user.getId())) {
+                throw new ConflictException(
+                        "User is already registered as a retailer and cannot become a supplier."
+                );
+        }
+
         // 2. Get or create Supplier
         Supplier supplier = supplierRepository.findById(dto.getSupplierId())
                 .orElseGet(() -> supplierRepository.save(
@@ -64,10 +71,19 @@ public class SupplierServiceImpl implements SupplierService {
                                 .user(user)
                                 .build()
                 ));
+        
+        if (user.getUserType() != null && user.getUserType() != UserType.SUPPLIER) {
+        throw new ConflictException("User type cannot be changed.");
+        }
 
-        // Récupère le userType depuis le DTO
-        user.setUserType(UserType.valueOf(dto.getUserType().toUpperCase()));
-        userRepository.save(user);
+        user.setUserType(UserType.SUPPLIER);
+
+        user.setUserOnboardingStatus(true);
+                userRepository.save(user);
+
+        // Register the user as a supplier if not already done
+        // user.setUserType(UserType.valueOf(dto.getUserType().toUpperCase()));
+        // userRepository.save(user);
         System.out.println("User Type is :" + user.getUserType());
 
         //  ADD HERE (IMPORTANT)
@@ -135,12 +151,12 @@ public class SupplierServiceImpl implements SupplierService {
         //Save supplier (which cascades and saves business too)
         Supplier savedSupplier = supplierRepository.save(supplier);
 
-        // Mettre à jour l'onboarding directement sur l'objet déjà chargé
-        if (!user.isUserOnboardingStatus()) {
-            user.setUserOnboardingStatus(true);
-            userRepository.save(user);
-            System.out.println("-------------------"+ user.isUserOnboardingStatus());
-        }
+        // // Mettre à jour l'onboarding directement sur l'objet déjà chargé
+        // if (!user.isUserOnboardingStatus()) {
+        //     user.setUserOnboardingStatus(true);
+        //     userRepository.save(user);
+        //     System.out.println("-------------------"+ user.isUserOnboardingStatus());
+        // }
 
         // Capture final IDs for response
         Set<String> savedCategoryIds = savedSupplier.getCategories()

--- a/src/main/java/com/sattva/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/sattva/service/impl/UserServiceImpl.java
@@ -5,6 +5,7 @@ import com.sattva.dto.UserDTO;
 import com.sattva.enums.RoleName;
 import com.sattva.enums.UserStatus;
 import com.sattva.enums.UserType;
+import com.sattva.exception.ConflictException;
 import com.sattva.exception.InvalidInputException;
 import com.sattva.exception.ResourceNotFoundException;
 import com.sattva.model.RefreshToken;
@@ -103,10 +104,19 @@ public class UserServiceImpl implements UserService {
             user.setPhoneNumber(userDTO.getPhoneNumber());
         }
         user.setPassword(userDTO.getPassword());
-        user.setUserType(userDTO.getUserType());
+        // user.setUserType(userDTO.getUserType());
         user.setStatus(userDTO.getStatus());
         user.setUserOnboardingStatus(userDTO.isOnboardingStatus());
         user.setFullName(userDTO.getFullName());
+        if (userDTO.getUserType() != null &&
+                user.getUserType() != null &&
+                userDTO.getUserType() != user.getUserType()) {
+                throw new ConflictException("User type cannot be changed.");
+            }
+
+            if (user.getUserType() == null) {
+                user.setUserType(userDTO.getUserType());
+            }
 
         if (userDTO.getRoles() != null && !userDTO.getRoles().isEmpty()) {
             Set<Role> updatedRoles = new HashSet<>();
@@ -126,21 +136,21 @@ public class UserServiceImpl implements UserService {
         // Save updated user
         User updatedUser = userRepository.save(user);
 
-        if (userDTO.getUserType() == UserType.SUPPLIER) {
-            if (!supplierRepository.existsById(userId)) {
-                Supplier supplier = new Supplier();
-                supplier.setUser(user);  // set the actual user object
-                supplierRepository.save(supplier);
-            }
-            retailerRepository.deleteById(userId);
-        } else if (userDTO.getUserType() == UserType.RETAILER) {
-            if (!retailerRepository.existsById(userId)) {
-                Retailer retailer = new Retailer();
-                retailer.setUser(user);  // set the actual user object
-                retailerRepository.save(retailer);
-            }
-            supplierRepository.deleteById(userId);
-        }
+        // if (userDTO.getUserType() == UserType.SUPPLIER) {
+        //     if (!supplierRepository.existsById(userId)) {
+        //         Supplier supplier = new Supplier();
+        //         supplier.setUser(user);  // set the actual user object
+        //         supplierRepository.save(supplier);
+        //     }
+        //     retailerRepository.deleteById(userId);
+        // } else if (userDTO.getUserType() == UserType.RETAILER) {
+        //     if (!retailerRepository.existsById(userId)) {
+        //         Retailer retailer = new Retailer();
+        //         retailer.setUser(user);  // set the actual user object
+        //         retailerRepository.save(retailer);
+        //     }
+        //     supplierRepository.deleteById(userId);
+        // }
 
         return mapToDTO(updatedUser);
     }


### PR DESCRIPTION
Implemented validation to ensure a phone number is associated with only one user type. Once a phone number is registered as either a Supplier or a Retailer, it cannot be used for the other user type, and the userType cannot be changed afterward.

